### PR TITLE
fix fatal error while using HTML5 MP3 recorder

### DIFF
--- a/classes/poodlltools.php
+++ b/classes/poodlltools.php
@@ -468,7 +468,7 @@ class poodlltools
 		$height = "170";
 		//$params['callbackjs']= 'poodll_audiosdk.audiohelper.poodllcallback';
 		$iframe_src_url = new \Moodle_URL("/filter/poodll/mp3recorderskins/$skin/index.php", $params);
-		$ret = html_writer::tag('iframe', '', array('src' => $iframe_src_url->out(false), 'frameBorder' => 0, 'scrolling' => 'none', 'allowTransparency' => 'true', 'class' => 'filter_poodll_mp3skinned_recorder'));
+		$ret = \html_writer::tag('iframe', '', array('src' => $iframe_src_url->out(false), 'frameBorder' => 0, 'scrolling' => 'none', 'allowTransparency' => 'true', 'class' => 'filter_poodll_mp3skinned_recorder'));
 		return $ret;
 
 


### PR DESCRIPTION
fix a fatal error while using skinned HTML5 MP3 recorder
core static class html_writer needs to be called outside of current namespace