### PR TITLE
added filter/poodll:use capability in order to limit access

### DIFF
--- a/db/access.php
+++ b/db/access.php
@@ -25,7 +25,14 @@
 defined('MOODLE_INTERNAL') || die();
 
 $capabilities = array(
-
+  'filter/poodll:use' => array(
+      'captype' => 'write',
+      'contextlevel' => CONTEXT_COURSE,
+      'archetypes' => array(
+          'manager' => CAP_ALLOW,
+          'editingteacher' => CAP_ALLOW
+      ),
+  ),
     'filter/poodll:candownloadmedia' => array(
         'captype' => 'read',
         'contextlevel' => CONTEXT_COURSE,

--- a/lang/en/filter_poodll.php
+++ b/lang/en/filter_poodll.php
@@ -130,7 +130,8 @@ $string['mobile_os_version_warning'] ='<p>Your OS Version is too low</p>
 
 $string['defaultwhiteboard'] = 'Default whiteboard';
 $string['whiteboardsave'] = 'Save Picture';
-$string['poodll:candownloadmedia'] = 'Can download media'; 
+$string['poodll:candownloadmedia'] = 'Can download media';
+$string['poodll:use'] = 'Can use the PoodLL filter'; 
 
 $string['bgtranscode_video'] = 'Perform Conversions to MP4 Background'; 
 $string['bgtranscodedetails_video'] = 'This is more reliable than performing them while user waits. But the user will not get their video till cron has run after saving. Only works if you are using FFMPEG and Moodle 2.7 or higher.'; 

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   =  2017121801;
+$plugin->version   =  2018012001;
 $plugin->requires  = 2016052300;//moodle 3.1.0
 $plugin->component = 'filter_poodll'; 
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->release   = '3.0.59(Build 2017121801)';
+$plugin->release   = '3.0.60(Build 2018012001)';


### PR DESCRIPTION
I've added a filter/poodll:use capability so that I am able to restrict access to a smaller number of instructors initially. It requires a version bump to register the capability. 

With this in place, it is possible to prevent access from the Moodle Teacher role, and then create another specific PoodLL role that allows us to further control on who can access the filter (and then related plugins). 

Thanks in advance for your consideration!