### PR TITLE
Fixing error in paypalplayer package.json that was causing grunt errors

### DIFF
--- a/3rdparty/paypalplayer/package.json
+++ b/3rdparty/paypalplayer/package.json
@@ -25,8 +25,8 @@
     "html5",
     "accessible",
     "video",
-    "player"
-    "paypal"
+    "player",
+    "paypal",
     "javascript"
   ],
   "author": "weboverhauls@gmail.com",


### PR DESCRIPTION
Right now, you get this error if you try to run grunt in Moodle with this plugin installed:

``
$ grunt
Running "startup" task

Running "stylelint:scss" (stylelint) task
Warning: Running stylelint failed
JSONError: JSON Error in /Users/rexlorenzo/Projects/moodle-docker/moodle/filter/poodll/3rdparty/paypalplayer/package.json:
Unexpected token '"' at 29:5
    "paypal"
    ^
    "paypal"
    ^
  at module.exports (/Users/rexlorenzo/Projects/moodle-docker/moodle/node_modules/parse-json/index.js:27:17)
  at module.exports (/Users/rexlorenzo/Projects/moodle-docker/moodle/node_modules/cosmiconfig/lib/parseJson.js:7:12)
  at /Users/rexlorenzo/Projects/moodle-docker/moodle/node_modules/cosmiconfig/lib/loadPackageProp.js:12:25
  at <anonymous>:null:null
 Use --force to continue.

Aborted due to warnings.
``

This error was fixed on the plugin source at: https://github.com/paypal/accessible-html5-video-player/commit/a64a28e4e2757c08a3b41f1e0e271a0db2642ba2

So you can accept this patch just to fix this minor issue or upgrade to 1.04 of the paypalplayer plugin.