### PR TITLE
Only read local_config once

### DIFF
--- a/filter.php
+++ b/filter.php
@@ -104,10 +104,18 @@ class filter_poodll extends moodle_text_filter {
     	//I just gave up and do it myself and stuff it in $this->courseconfig . bug?? Justin 20150106
     	if($this->localconfig && !empty($this->localconfig)){
     		$this->courseconfig = $this->localconfig;
-    	}
-    	if(!$this->courseconfig){
-    		$this->courseconfig = filter_get_local_config('poodll', context_course::instance($COURSE->id)->id);
-    	}
+		}
+
+        if ($this->courseconfig === null) {
+            $cache = \cache::make_from_params(\cache_store::MODE_REQUEST, 'filter_poodll', 'local_config');
+            $contextid = context_course::instance($COURSE->id)->id;
+            $data = $cache->get($contextid);
+            if ($data === false) {
+                $data = filter_get_local_config('poodll', $contextid);
+                $cache->set($contextid, $data);
+            }
+            $this->courseconfig = $data;
+        }
     	
 		if($this->courseconfig && isset($this->courseconfig[$prop]) && $this->courseconfig[$prop] != 'sitedefault') {
 			return $this->courseconfig[$prop];


### PR DESCRIPTION
Without this change, filter_poodll is performing lookups for config far
more than necessary. This change reduces it to *one* read total per page
view.

On any given page, it should only need to load the course config *once*.
However without this patch we actually see:

course with no set poodll config:
* 8*invocations
course with set poodll config:
* 1*invocations

Where an "invocation" is a call to the filter - so for every label and
such on the page. We're seeing an average of 50 DB reads for the same
data in course views as a result.