### PR TITLE
Issue#44 : Fix unit test failures

### DIFF
--- a/classes/external.php
+++ b/classes/external.php
@@ -13,9 +13,7 @@ use filter_poodll\poodlltools;
 use filter_poodll\constants;
 use filter_poodll\diff;
 
-use external_api;
-use external_function_parameters;
-use external_value;
+
 /**
  * External class.
  *


### PR DESCRIPTION
The use statement is used to import classes or namespaces from external files. However, the external_function_parameters class seems to be part of the Moodle's external API, which is in the global namespace. Therefore, you don't need to import it with a use statement.