### PR TITLE
Set default player value to empty string (none option)

### DIFF
--- a/classes/settingstools.php
+++ b/classes/settingstools.php
@@ -390,13 +390,13 @@ class settingstools {
             $ext = trim($ext);
             switch ($ext) {
                 case 'youtube':
-                    $def_player = '1';
+                    $def_player = '';
                     break;
                 case 'rss':
-                    $def_player = '1';
+                    $def_player = '';
                     break;
                 default:
-                    $def_player = '1';
+                    $def_player = '';
             }
             $items[] = new \admin_setting_configcheckbox('filter_poodll/handle' . $ext,
                     get_string('handle', 'filter_poodll', strtoupper($ext)), '', 0);


### PR DESCRIPTION
**Description:** Resolve https://github.com/justinhunt/moodle-filter_poodll/issues/49

```
root@8b401fdd09dd:/var/www/site# vendor/bin/phpunit --filter test_admin_apply_default_settings lib/tests/adminlib_test.php
Moodle 4.5.10+ (Build: 20260306), a41a91ba74423f6d647f1e0018484264a7fa47da
Php: 8.3.27, mysqli: 8.0.45, OS: Linux 6.17.0-19-generic x86_64
PHPUnit 9.6.18 by Sebastian Bergmann and contributors.

.                                                                   1 / 1 (100%)

Time: 00:07.406, Memory: 136.00 MB

OK (1 test, 6 assertions)
```